### PR TITLE
Replace kaniko with buildah

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,8 @@ of the [config](./ssh/config) file
 You can configure the execution parameters by changing the content of [run.properties](./kustomize/run/run.properties).
 
 ## Tekton Hub Tasks
-The following tasks are automatically installed and oatched by the installation procedure:
+The following task is automatically installed and patched by the installation procedure:
 * [git cli](https://hub.tekton.dev/tekton/task/git-cli)
-* [kaniko](https://hub.tekton.dev/tekton/task/kaniko)
 
 ## Install
 Deploy the required Tekton tasks and pipeline:

--- a/kustomize/base/pipeline.yaml
+++ b/kustomize/base/pipeline.yaml
@@ -106,7 +106,8 @@ spec:
     - name: build-and-push-image
       runAfter: ["flatten-workflow"]
       taskRef:
-        name: kaniko
+        name: buildah
+        kind: ClusterTask        
       workspaces:
         - name: source
           workspace: workflow-source
@@ -119,6 +120,8 @@ spec:
           value: flat/workflow-builder.Dockerfile
         - name: CONTEXT
           value: flat/$(params.workflowId)
+        - name: BUILD_EXTRA_ARGS
+          value: --ulimit nofile=4096:4096             
     - name: push-workflow-config
       runAfter: ["build-config", "build-and-push-image"]
       taskRef:

--- a/kustomize/hub/kustomization.yaml
+++ b/kustomize/hub/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://api.hub.tekton.dev/v1/resource/tekton/task/kaniko/0.6/raw
   - https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-cli/0.4/git-cli.yaml
 
 namespace: sonataflow-infra


### PR DESCRIPTION
This PR replaces kaniko as the container image builder tool for buildah. The buildah cluster task is provided as part of the OpenShift Pipelines Operator deployment.

@dmartinol @masayag @rgolangh PTAL.